### PR TITLE
Fixed minor bugs in CaseStudy.ipynb

### DIFF
--- a/memtorch/examples/CaseStudy.ipynb
+++ b/memtorch/examples/CaseStudy.ipynb
@@ -491,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/memtorch/examples/CaseStudy.ipynb
+++ b/memtorch/examples/CaseStudy.ipynb
@@ -373,7 +373,10 @@
    "outputs": [],
    "source": [
     "# Determine the F1 score\n",
-    "non_linear_reference_memristor_params = {'time_series_resolution': 1e-6,\n",
+    "df = pd.DataFrame(columns=['sigma', 'mean', 'std'])\n",
+    "sigma_values = np.linspace(0, 500, 21)\n",
+    "for sigma in sigma_values:\n",
+    "    non_linear_reference_memristor_params = {'time_series_resolution': 1e-6,\n",
     "                              'alpha_off': 1,\n",
     "                              'alpha_on': 3,\n",
     "                              'v_off': 0.5,\n",
@@ -385,10 +388,6 @@
     "                              'd': 10e-9,\n",
     "                              'x_on': 0,\n",
     "                              'x_off': 10e-9}\n",
-    "\n",
-    "df = pd.DataFrame(columns=['sigma', 'mean', 'std'])\n",
-    "sigma_values = np.linspace(0, 500, 21)\n",
-    "for sigma in sigma_values:\n",
     "    f1_scores = []\n",
     "    for fold in range(len(test_loaders)):\n",
     "        net = EEGNet()\n",
@@ -492,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In Section 5 : Device-to-device variability investigation, "non_linear_reference_memristor_params" accepts "sigma" as an argument. Therefore the instantiation should be done inside the sigma loop.