### PR TITLE
Modularized Input Scaling and Added `force_scale` Input Argument to the Default Scaling Method

### DIFF
--- a/memtorch/map/Input.py
+++ b/memtorch/map/Input.py
@@ -1,0 +1,27 @@
+import numpy as np
+import torch
+import torch.functional as F
+import torch.nn as nn
+
+import memtorch
+from memtorch.utils import convert_range
+
+
+def naive_scale(module, input):
+    if module.max_input_voltage is not None:
+        assert (
+            type(module.max_input_voltage) == int
+            or type(module.max_input_voltage) == float
+        ) and module.max_input_voltage > 0, (
+            "The maximum input voltage (max_input_voltage) must be >0."
+        )
+        input_range = torch.amax(torch.abs(input))
+        input = convert_range(
+            input,
+            -input_range,
+            input_range,
+            -module.max_input_voltage,
+            module.max_input_voltage,
+        )
+
+    return input

--- a/memtorch/map/Input.py
+++ b/memtorch/map/Input.py
@@ -7,7 +7,7 @@ import memtorch
 from memtorch.utils import convert_range
 
 
-def naive_scale(module, input):
+def naive_scale(module, input, force_scale=False):
     if module.max_input_voltage is not None:
         assert (
             type(module.max_input_voltage) == int
@@ -16,12 +16,15 @@ def naive_scale(module, input):
             "The maximum input voltage (max_input_voltage) must be >0."
         )
         input_range = torch.amax(torch.abs(input))
-        input = convert_range(
-            input,
-            -input_range,
-            input_range,
-            -module.max_input_voltage,
-            module.max_input_voltage,
-        )
+        if not force_scale and input_range <= module.max_input_voltage:
+            return input
+        else:
+            return convert_range(
+                input,
+                -input_range,
+                input_range,
+                -module.max_input_voltage,
+                module.max_input_voltage,
+            )
 
     return input

--- a/memtorch/map/__init__.py
+++ b/memtorch/map/__init__.py
@@ -1,2 +1,3 @@
+from .Input import *
 from .Module import *
 from .Parameter import *

--- a/memtorch/mn/Conv1d.py
+++ b/memtorch/mn/Conv1d.py
@@ -7,9 +7,9 @@ import torch.nn as nn
 import memtorch
 from memtorch.bh.crossbar.Crossbar import init_crossbar, simulate_matmul
 from memtorch.bh.crossbar.Tile import gen_tiles, tile_matmul
+from memtorch.map.Input import naive_scale
 from memtorch.map.Module import naive_tune
 from memtorch.map.Parameter import naive_map
-from memtorch.utils import convert_range, pad_tensor
 
 
 class Conv1d(nn.Conv1d):
@@ -39,6 +39,10 @@ class Conv1d(nn.Conv1d):
         Tile shape to use to store weights. If None, modular tiles are not used.
     max_input_voltage : float
         Maximum input voltage used to encode inputs. If None, inputs are unbounded.
+    scaling_routine : function
+        Scaling routine to use in order to scale batch inputs.
+    scaling_routine_params : **kwargs
+        Scaling routine keyword arguments.
     ADC_resolution : int
         ADC resolution (bit width). If None, quantization noise is not accounted for.
     ADC_overflow_rate : float
@@ -64,6 +68,8 @@ class Conv1d(nn.Conv1d):
         scheme=memtorch.bh.Scheme.DoubleColumn,
         tile_shape=None,
         max_input_voltage=None,
+        scaling_routine=naive_scale,
+        scaling_routine_params={},
         ADC_resolution=None,
         ADC_overflow_rate=0.0,
         quant_method=None,
@@ -79,6 +85,8 @@ class Conv1d(nn.Conv1d):
         self.scheme = scheme
         self.tile_shape = tile_shape
         self.max_input_voltage = max_input_voltage
+        self.scaling_routine = scaling_routine
+        self.scaling_routine_params = scaling_routine_params
         self.ADC_resolution = ADC_resolution
         self.ADC_overflow_rate = ADC_overflow_rate
         if quant_method in memtorch.bh.Quantize.quant_methods:
@@ -168,21 +176,7 @@ class Conv1d(nn.Conv1d):
             if not all(item == 0 for item in self.padding):
                 input = nn.functional.pad(input, pad=(self.padding[0], self.padding[0]))
 
-            if self.max_input_voltage is not None:
-                assert (
-                    type(self.max_input_voltage) == int
-                    or type(self.max_input_voltage) == float
-                ) and self.max_input_voltage > 0, (
-                    "The maximum input voltage (max_input_voltage) must be >0."
-                )
-                input = convert_range(
-                    input,
-                    input.min(),
-                    input.max(),
-                    -self.max_input_voltage,
-                    self.max_input_voltage,
-                )
-
+            input = self.scaling_routine(self, input, **self.scaling_routine_params)
             for batch in range(input.shape[0]):
                 unfolded_batch_input = (
                     input[batch]

--- a/memtorch/mn/Conv3d.py
+++ b/memtorch/mn/Conv3d.py
@@ -7,9 +7,9 @@ import torch.nn as nn
 import memtorch
 from memtorch.bh.crossbar.Crossbar import init_crossbar, simulate_matmul
 from memtorch.bh.crossbar.Tile import gen_tiles, tile_matmul
+from memtorch.map.Input import naive_scale
 from memtorch.map.Module import naive_tune
 from memtorch.map.Parameter import naive_map
-from memtorch.utils import convert_range, pad_tensor
 
 
 class Conv3d(nn.Conv3d):
@@ -39,6 +39,10 @@ class Conv3d(nn.Conv3d):
         Tile shape to use to store weights. If None, modular tiles are not used.
     max_input_voltage : float
         Maximum input voltage used to encode inputs. If None, inputs are unbounded.
+    scaling_routine : function
+        Scaling routine to use in order to scale batch inputs.
+    scaling_routine_params : **kwargs
+        Scaling routine keyword arguments.
     ADC_resolution : int
         ADC resolution (bit width). If None, quantization noise is not accounted for.
     ADC_overflow_rate : float
@@ -64,6 +68,8 @@ class Conv3d(nn.Conv3d):
         scheme=memtorch.bh.Scheme.DoubleColumn,
         tile_shape=None,
         max_input_voltage=None,
+        scaling_routine=naive_scale,
+        scaling_routine_params={},
         ADC_resolution=None,
         ADC_overflow_rate=0.0,
         quant_method=None,
@@ -79,6 +85,8 @@ class Conv3d(nn.Conv3d):
         self.scheme = scheme
         self.tile_shape = tile_shape
         self.max_input_voltage = max_input_voltage
+        self.scaling_routine = scaling_routine
+        self.scaling_routine_params = scaling_routine_params
         self.ADC_resolution = ADC_resolution
         self.ADC_overflow_rate = ADC_overflow_rate
         if quant_method in memtorch.bh.Quantize.quant_methods:
@@ -202,21 +210,9 @@ class Conv3d(nn.Conv3d):
                 else:
                     batch_input = input[batch]
 
-                if self.max_input_voltage is not None:
-                    assert (
-                        type(self.max_input_voltage) == int
-                        or type(self.max_input_voltage) == float
-                    ) and self.max_input_voltage > 0, (
-                        "The maximum input voltage (max_input_voltage) must be >0."
-                    )
-                    batch_input = convert_range(
-                        batch_input,
-                        batch_input.min(),
-                        batch_input.max(),
-                        -self.max_input_voltage,
-                        self.max_input_voltage,
-                    )
-
+                batch_input = self.scaling_routine(
+                    self, batch_input, **self.scaling_routine_params
+                )
                 unfolded_batch_input = (
                     batch_input.unfold(1, self.kernel_size[0], self.stride[0])
                     .unfold(2, self.kernel_size[1], self.stride[1])

--- a/memtorch/mn/Linear.py
+++ b/memtorch/mn/Linear.py
@@ -10,7 +10,6 @@ from memtorch.bh.crossbar.Tile import gen_tiles, tile_matmul
 from memtorch.map.Input import naive_scale
 from memtorch.map.Module import naive_tune
 from memtorch.map.Parameter import naive_map
-from memtorch.utils import convert_range, pad_tensor
 
 
 class Linear(nn.Linear):
@@ -162,7 +161,7 @@ class Linear(nn.Linear):
             return out
         else:
             input_shape = input.shape
-            self.scaling_routine(self, input, **self.scaling_routine_params)
+            input = self.scaling_routine(self, input, **self.scaling_routine_params)
             if hasattr(self, "non_linear"):
                 if self.tile_shape is not None:
                     tiles_map = self.crossbars[0].tiles_map

--- a/memtorch/mn/Linear.py
+++ b/memtorch/mn/Linear.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 import memtorch
 from memtorch.bh.crossbar.Crossbar import init_crossbar, simulate_matmul
 from memtorch.bh.crossbar.Tile import gen_tiles, tile_matmul
+from memtorch.map.Input import naive_scale
 from memtorch.map.Module import naive_tune
 from memtorch.map.Parameter import naive_map
 from memtorch.utils import convert_range, pad_tensor
@@ -39,6 +40,10 @@ class Linear(nn.Linear):
         Tile shape to use to store weights. If None, modular tiles are not used.
     max_input_voltage : float
         Maximum input voltage used to encode inputs. If None, inputs are unbounded.
+    scaling_routine : function
+        Scaling routine to use in order to scale batch inputs.
+    scaling_routine_params : **kwargs
+        Scaling routine keyword arguments.
     ADC_resolution : int
         ADC resolution (bit width). If None, quantization noise is not accounted for.
     ADC_overflow_rate : float
@@ -64,6 +69,8 @@ class Linear(nn.Linear):
         scheme=memtorch.bh.Scheme.DoubleColumn,
         tile_shape=None,
         max_input_voltage=None,
+        scaling_routine=naive_scale,
+        scaling_routine_params={},
         ADC_resolution=None,
         ADC_overflow_rate=0.0,
         quant_method=None,
@@ -79,6 +86,8 @@ class Linear(nn.Linear):
         self.scheme = scheme
         self.tile_shape = tile_shape
         self.max_input_voltage = max_input_voltage
+        self.scaling_routine = scaling_routine
+        self.scaling_routine_params = scaling_routine_params
         self.ADC_resolution = ADC_resolution
         self.ADC_overflow_rate = ADC_overflow_rate
         if quant_method in memtorch.bh.Quantize.quant_methods:
@@ -153,22 +162,7 @@ class Linear(nn.Linear):
             return out
         else:
             input_shape = input.shape
-            if self.max_input_voltage is not None:
-                assert (
-                    type(self.max_input_voltage) == int
-                    or type(self.max_input_voltage) == float
-                ) and self.max_input_voltage > 0, (
-                    "The maximum input voltage (max_input_voltage) must be >0."
-                )
-                input_range = torch.amax(torch.abs(input))
-                input = convert_range(
-                    input,
-                    -input_range,
-                    input_range,
-                    -self.max_input_voltage,
-                    self.max_input_voltage,
-                )
-
+            self.scaling_routine(self, input, **self.scaling_routine_params)
             if hasattr(self, "non_linear"):
                 if self.tile_shape is not None:
                     tiles_map = self.crossbars[0].tiles_map

--- a/memtorch/mn/Module.py
+++ b/memtorch/mn/Module.py
@@ -5,6 +5,7 @@ import torch
 import torch.functional as F
 
 import memtorch
+from memtorch.map.Input import naive_scale
 from memtorch.map.Parameter import naive_map
 
 from .Conv1d import Conv1d
@@ -33,6 +34,8 @@ def patch_model(
     scheme=memtorch.bh.Scheme.DoubleColumn,
     tile_shape=None,
     max_input_voltage=None,
+    scaling_routine=naive_scale,
+    scaling_routine_params={},
     ADC_resolution=None,
     ADC_overflow_rate=0.0,
     quant_method=None,
@@ -68,6 +71,10 @@ def patch_model(
         Tile shape to use to store weights. If None, modular tiles are not used.
     max_input_voltage : float
         Maximum input voltage used to encode inputs. If None, inputs are unbounded.
+    scaling_routine : function
+        Scaling routine to use in order to scale batch inputs.
+    scaling_routine_params : **kwargs
+        Scaling routine keyword arguments.
     ADC_resolution : int
         ADC resolution (bit width). If None, quantization noise is not accounted for.
     ADC_overflow_rate : float
@@ -112,6 +119,8 @@ def patch_model(
                             scheme=scheme,
                             tile_shape=tile_shape,
                             max_input_voltage=max_input_voltage,
+                            scaling_routine=scaling_routine,
+                            scaling_routine_params=scaling_routine_params,
                             ADC_resolution=ADC_resolution,
                             ADC_overflow_rate=ADC_overflow_rate,
                             quant_method=quant_method,
@@ -136,6 +145,8 @@ def patch_model(
                             scheme=scheme,
                             tile_shape=tile_shape,
                             max_input_voltage=max_input_voltage,
+                            scaling_routine=scaling_routine,
+                            scaling_routine_params=scaling_routine_params,
                             ADC_resolution=ADC_resolution,
                             ADC_overflow_rate=ADC_overflow_rate,
                             quant_method=quant_method,


### PR DESCRIPTION
Added functionality as discussed in #80:

1. Created `memtorch.map.Input` to encapsulate customizable input scaling methods.
2. Modularized input scaling logic for all layer types.
3. Added the `force_scale` input argument to the default scaling method to specify whether inputs are force scaled if they do not exceed `max_input_voltage`.