### PR TITLE
Fix a BUG to recognize custom parameters of RRAM model correctly

### DIFF
--- a/memtorch/bh/crossbar/Crossbar.py
+++ b/memtorch/bh/crossbar/Crossbar.py
@@ -65,14 +65,14 @@ class Crossbar:
         self.tile_shape = tile_shape
         self.use_bindings = use_bindings
         self.cuda_malloc_heap_size = cuda_malloc_heap_size
-        if hasattr(memristor_model_params, "r_off"):
+        if "r_off" in memristor_model_params.keys():
             self.r_off_mean = memristor_model_params["r_off"]
             if callable(self.r_off_mean):
                 self.r_off_mean = self.r_off_mean()
         else:
             self.r_off_mean = memristor_model().r_off
 
-        if hasattr(memristor_model_params, "r_on"):
+        if "r_on" in memristor_model_params.keys():
             self.r_on_mean = memristor_model_params["r_on"]
             if callable(self.r_on_mean):
                 self.r_on_mean = self.r_on_mean()


### PR DESCRIPTION
when i try to set different parameters of the VTEAM model,i found that some parameters did not really work and they just keep as default value. After debugging, it was found that 'hasattr()' function can't judge keys in a dict, so i recommend replace it with dict.key(), or is this issue caused by my wrong way set the parameters like this:

reference_memristor_params = {'time_series_resolution': 1e-12,'r_off':1e5,'r_on':1e2,'v_on':-0.3,'v_off':0.3}